### PR TITLE
Add eslint-plugin-eslint-comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = {
   extends: [
     'eslint-config-airbnb-base',
     'eslint-config-prettier',
+    'plugin:eslint-comments/recommended',
     bestPractices,
     errors,
     es6,
@@ -39,6 +40,7 @@ module.exports = {
       rules: {
         'array-bracket-newline': 'off',
         'array-element-newline': 'off',
+        'eslint-comments/no-unused-disable': 'error',
         'id-length': 'off',
         'jest/consistent-test-it': [
           'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tc",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1921,6 +1921,24 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-eslint-comments": {
+      "version": "3.1.2",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.1.2.tgz",
+      "integrity": "sha1-TvbEiNvgaqFif+oQez5dBZ/Io5U=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha1-hLez2+ZFUrbvDsqZ9nQ9vsbZet8=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tc",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "ESLint shareable config for JavaScript projects",
   "keywords": [
     "eslintconfig",
@@ -35,6 +35,7 @@
   "devDependencies": {
     "eslint": "^6.6.0",
     "eslint-formatter-pretty": "^3.0.0",
+    "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jest": "^23.0.2",
     "eslint-plugin-prettier": "^3.1.1",


### PR DESCRIPTION
This PR aims to add [eslint-plugin-eslint-comments](https://mysticatea.github.io/eslint-plugin-eslint-comments/) to the ruleset. It's goals are to ensure that we are properly using eslint-disable statements and also don't have unnecessary disable statements that are no longer used.