### PR TITLE
Turn off no-underscore-dangle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tc",
-  "version": "13.0.1",
+  "version": "13.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tc",
-  "version": "13.0.1",
+  "version": "13.0.2",
   "description": "ESLint shareable config for JavaScript projects",
   "keywords": [
     "eslintconfig",

--- a/rules/style.js
+++ b/rules/style.js
@@ -13,6 +13,7 @@ module.exports = {
     'new-cap': 'error',
     'no-inline-comments': 'error',
     'no-negated-condition': 'error',
+    'no-underscore-dangle': 'off',
     'padding-line-between-statements': [
       'error',
       {blankLine: 'always', prev: '*', next: 'return'},


### PR DESCRIPTION
Turn off no-underscore-dangle to avoid unnecessary noise in adoption. 