### PR TITLE
16.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ First thing first, let's make sure you have the necessary pre-requisites.
 npx install-peerdeps --dev eslint-config-tc
 ```
 
-> eslint, eslint-plugin-import, eslint-plugin-prettier, and prettier are peer dependencies and must be installed.
+> eslint, eslint-plugin-eslint-comments, eslint-plugin-import, eslint-plugin-jest, eslint-plugin-prettier, eslint-plugin-unicorn, and prettier are peer dependencies and must be installed.
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -35,10 +35,6 @@ module.exports = {
   overrides: [
     {
       files: ['**/*.spec.js', '**/*.test.js', '**/tests-*.js'],
-      env: {
-        jest: true,
-        mocha: true,
-      },
       rules: {
         'array-bracket-newline': 'off',
         'array-element-newline': 'off',

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
     'eslint:recommended',
     'eslint-config-prettier',
     'plugin:eslint-comments/recommended',
+    'plugin:unicorn/recommended',
     bestPractices,
     errors,
     es6,

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const node = require.resolve('./rules/node');
 const style = require.resolve('./rules/style');
 const variables = require.resolve('./rules/variables');
 const prettier = require.resolve('./rules/prettier');
+const jest = require.resolve('./rules/jest');
 
 module.exports = {
   extends: [
@@ -12,6 +13,7 @@ module.exports = {
     'eslint:recommended',
     'eslint-config-prettier',
     'plugin:eslint-comments/recommended',
+    'plugin:jest/recommended',
     'plugin:unicorn/recommended',
     bestPractices,
     errors,
@@ -20,6 +22,7 @@ module.exports = {
     style,
     variables,
     prettier,
+    jest,
   ],
   plugins: ['jest', 'prettier'],
   parserOptions: {
@@ -34,61 +37,18 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['**/*.spec.js', '**/*.test.js', '**/tests-*.js'],
+      files: ['**/*.spec.js', '**/*.test.js', '**/tests-*.js', '**/*.spec.ts', '**/*.test.ts', '**/tests-*.ts'],
       rules: {
         'array-bracket-newline': 'off',
         'array-element-newline': 'off',
         'eslint-comments/no-unused-disable': 'error',
         'id-length': 'off',
-        'jest/consistent-test-it': [
-          'error',
-          {
-            fn: 'test',
-            withinDescribe: 'test',
-          },
-        ],
-        'jest/expect-expect': 'error',
-        'jest/no-alias-methods': 'error',
-        'jest/no-commented-out-tests': 'error',
-        'jest/no-conditional-expect': 'error',
-        'jest/no-deprecated-functions': 'error',
-        'jest/no-interpolation-in-snapshots': 'error',
-        'jest/no-disabled-tests': 'error',
-        'jest/no-duplicate-hooks': 'error',
-        'jest/no-export': 'error',
-        'jest/no-focused-tests': 'error',
-        'jest/no-identical-title': 'error',
-        'jest/no-if': 'error',
-        'jest/no-jasmine-globals': 'error',
-        'jest/no-jest-import': 'error',
-        'jest/no-large-snapshots': 'error',
-        'jest/no-standalone-expect': 'error',
-        'jest/no-test-prefixes': 'error',
-        'jest/no-done-callback': 'error',
-        'jest/no-test-return-statement': 'error',
-        'jest/no-truthy-falsy': 'error',
-        'jest/no-try-expect': 'error',
-        'jest/prefer-called-with': 'error',
-        'jest/prefer-hooks-on-top': 'error',
-        'jest/prefer-strict-equal': 'error',
-        'jest/prefer-to-be-null': 'error',
-        'jest/prefer-to-be-undefined': 'error',
-        'jest/prefer-to-contain': 'error',
-        'jest/prefer-to-have-length': 'error',
-        'jest/prefer-todo': 'error',
-        'jest/require-to-throw-message': 'error',
-        'jest/require-top-level-describe': 'error',
-        'jest/valid-describe': 'error',
-        'jest/valid-expect-in-promise': 'error',
-        'jest/valid-expect': 'error',
-        'jest/valid-title': 'error',
         'max-lines': 'off',
         'max-lines-per-function': 'off',
         'max-nested-callbacks': 'off',
         'max-statements': 'off',
         'newline-after-var': 'off',
         'no-process-env': 'off',
-        'no-undefined': 'off',
         'object-curly-newline': 'off',
         'padding-line-between-statements': [
           'error',

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const node = require.resolve('./rules/node');
 const style = require.resolve('./rules/style');
 const variables = require.resolve('./rules/variables');
 const prettier = require.resolve('./rules/prettier');
-const jest = require.resolve('./rules/jest');
+const jestRules = require.resolve('./rules/jest');
 
 module.exports = {
   extends: [
@@ -22,7 +22,7 @@ module.exports = {
     style,
     variables,
     prettier,
-    jest,
+    jestRules,
   ],
   plugins: ['jest', 'prettier'],
   parserOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tc",
-  "version": "15.0.0",
+  "version": "16.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1152,6 +1152,20 @@
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
       "dev": true
     },
+    "babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      }
+    },
     "babel-jest": {
       "version": "26.3.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.3.0.tgz",
@@ -1472,6 +1486,15 @@
             "is-descriptor": "^0.1.0"
           }
         }
+      }
+    },
+    "clean-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
+      "integrity": "sha1-jffHquUf02h06PjQW5GAvBGj/tc=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "cliui": {
@@ -2048,6 +2071,16 @@
         }
       }
     },
+    "eslint-ast-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-ast-utils/-/eslint-ast-utils-1.1.0.tgz",
+      "integrity": "sha512-otzzTim2/1+lVrlH19EfQQJEhVJSu0zOb9ygb3iapN6UlyaDtyRq4b5U1FuW0v1lRa9Fp/GJyHkSwm6NqABgCA==",
+      "dev": true,
+      "requires": {
+        "lodash.get": "^4.4.2",
+        "lodash.zip": "^4.2.0"
+      }
+    },
     "eslint-config-airbnb-base": {
       "version": "14.2.0",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.0.tgz",
@@ -2244,6 +2277,130 @@
         "prettier-linter-helpers": "^1.0.0"
       }
     },
+    "eslint-plugin-unicorn": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-22.0.0.tgz",
+      "integrity": "sha512-jXPOauNiVFYLr+AeU3l21Ao+iDl/G08vUWui21RCI2L1TJIIoJvAMjMR6I+QPKr8FgIumzuR6gzDKCtEx2IkzA==",
+      "dev": true,
+      "requires": {
+        "ci-info": "^2.0.0",
+        "clean-regexp": "^1.0.0",
+        "eslint-ast-utils": "^1.1.0",
+        "eslint-template-visitor": "^2.2.1",
+        "eslint-utils": "^2.1.0",
+        "import-modules": "^2.0.0",
+        "lodash": "^4.17.20",
+        "pluralize": "^8.0.0",
+        "read-pkg-up": "^7.0.1",
+        "regexp-tree": "^0.1.21",
+        "reserved-words": "^0.1.2",
+        "safe-regex": "^2.1.1",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+              "dev": true
+            }
+          }
+        },
+        "read-pkg-up": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+          "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.1.0",
+            "read-pkg": "^5.2.0",
+            "type-fest": "^0.8.1"
+          }
+        },
+        "safe-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+          "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+          "dev": true,
+          "requires": {
+            "regexp-tree": "~0.1.1"
+          }
+        }
+      }
+    },
     "eslint-rule-docs": {
       "version": "1.1.207",
       "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.207.tgz",
@@ -2258,6 +2415,18 @@
       "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-template-visitor": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-template-visitor/-/eslint-template-visitor-2.2.1.tgz",
+      "integrity": "sha512-q3SxoBXz0XjPGkUpwGVAwIwIPIxzCAJX1uwfVc8tW3v7u/zS7WXNH3I2Mu2MDz2NgSITAyKLRaQFPHu/iyKxDQ==",
+      "dev": true,
+      "requires": {
+        "babel-eslint": "^10.1.0",
+        "eslint-visitor-keys": "^1.3.0",
+        "esquery": "^1.3.1",
+        "multimap": "^1.1.0"
       }
     },
     "eslint-utils": {
@@ -3100,6 +3269,12 @@
           }
         }
       }
+    },
+    "import-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.0.0.tgz",
+      "integrity": "sha512-iczM/v9drffdNnABOKwj0f9G3cFDon99VcG1mxeBsdqnbd+vnQ5c2uAiCHNQITqFTOPaEvwg3VjoWCur0uHLEw==",
+      "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -4222,10 +4397,22 @@
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "lodash.zip": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
       "dev": true
     },
     "log-symbols": {
@@ -4528,6 +4715,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "multimap": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
+      "integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==",
       "dev": true
     },
     "nanomatch": {
@@ -4948,6 +5141,12 @@
         "irregular-plurals": "^3.2.0"
       }
     },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -5111,6 +5310,12 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regexp-tree": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.21.tgz",
+      "integrity": "sha512-kUUXjX4AnqnR8KRTCrayAo9PzYMRKmVoGgaz2tBuz0MF3g1ZbGebmtW0yFHfFK9CmBjQKeYIgoL22pFLBJY7sw==",
+      "dev": true
+    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
@@ -5223,6 +5428,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "reserved-words": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
+      "integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=",
       "dev": true
     },
     "resolve": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tc",
-  "version": "15.0.0",
+  "version": "16.0.0",
   "description": "ESLint shareable config for JavaScript projects",
   "keywords": [
     "eslintconfig",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test": "jest"
   },
   "devDependencies": {
+    "@jest/globals": "^26.4.2",
     "eslint": "^7.10.0",
     "eslint-formatter-pretty": "^4.0.0",
     "eslint-plugin-eslint-comments": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.0.2",
     "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-unicorn": "^22.0.0",
     "is-plain-obj": "^2.1.0",
     "jest": "^26.4.2",
     "npm-package-json-lint": "^5.1.0",
@@ -55,6 +56,7 @@
     "eslint-plugin-import": "^2.0.0",
     "eslint-plugin-jest": "^24.0.2",
     "eslint-plugin-prettier": "^3.0.0",
+    "eslint-plugin-unicorn": "^22.0.0",
     "prettier": "^2.0.0"
   },
   "engines": {

--- a/rules/jest.js
+++ b/rules/jest.js
@@ -1,0 +1,28 @@
+module.exports = {
+  rules: {
+    'jest/consistent-test-it': [
+      'error',
+      {
+        fn: 'test',
+        withinDescribe: 'test',
+      },
+    ],
+    'jest/no-alias-methods': 'error',
+    'jest/no-duplicate-hooks': 'error',
+    'jest/no-if': 'error',
+    'jest/no-large-snapshots': 'error',
+    'jest/no-test-return-statement': 'error',
+    'jest/no-truthy-falsy': 'error',
+    'jest/no-try-expect': 'error',
+    'jest/prefer-called-with': 'error',
+    'jest/prefer-hooks-on-top': 'error',
+    'jest/prefer-strict-equal': 'error',
+    'jest/prefer-to-be-null': 'error',
+    'jest/prefer-to-be-undefined': 'error',
+    'jest/prefer-to-contain': 'error',
+    'jest/prefer-to-have-length': 'error',
+    'jest/prefer-todo': 'error',
+    'jest/require-to-throw-message': 'error',
+    'jest/require-top-level-describe': 'error',
+  },
+};

--- a/test/tests.test.js
+++ b/test/tests.test.js
@@ -1,7 +1,7 @@
 const {describe, test, expect} = require('@jest/globals');
 const eslint = require('eslint');
 const isPlainObj = require('is-plain-obj');
-const eslintConfig = require('../index.js');
+const eslintConfig = require('..');
 
 describe('eslint config tests', () => {
   describe('eslint object', () => {
@@ -31,8 +31,8 @@ describe('eslint config tests', () => {
   describe('run eslint and make sure it runs', () => {
     test('eslint should run without failing', () => {
       const code = 'console.log("doh, I used the wrong quotes");\n';
-      const expectedErrorLineNum = 1;
-      const expectedErrorColumnNum = 1;
+      const expectedErrorLineNumber = 1;
+      const expectedErrorColumnNumber = 1;
       const linter = new eslint.CLIEngine({
         useEslintrc: false,
         baseConfig: eslintConfig,
@@ -42,8 +42,8 @@ describe('eslint config tests', () => {
       const error = errors[0];
 
       expect(error.ruleId).toStrictEqual('no-console');
-      expect(error.line).toStrictEqual(expectedErrorLineNum);
-      expect(error.column).toStrictEqual(expectedErrorColumnNum);
+      expect(error.line).toStrictEqual(expectedErrorLineNumber);
+      expect(error.column).toStrictEqual(expectedErrorColumnNumber);
       expect(error.message).toStrictEqual('Unexpected console statement.');
     });
   });

--- a/test/tests.test.js
+++ b/test/tests.test.js
@@ -1,3 +1,4 @@
+const {describe, test, expect} = require('@jest/globals');
 const eslint = require('eslint');
 const isPlainObj = require('is-plain-obj');
 const eslintConfig = require('../index.js');


### PR DESCRIPTION
Add `eslint-plugin-unicorn`. - Closes #140
Remove jest and mocha environments from config. - Closes #220
Move jest config to extends instead of overrides. - Closes #221
Add override support for TypeScript files. `'**/*.spec.ts', '**/*.test.ts', '**/tests-*.ts'`