### PR TITLE
Remove `import/no extraneous dependencies` overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tc",
-  "version": "16.3.0",
+  "version": "16.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tc",
-  "version": "16.3.0",
+  "version": "16.3.1",
   "description": "ESLint shareable config for JavaScript projects",
   "keywords": [
     "eslintconfig",

--- a/rules/import.js
+++ b/rules/import.js
@@ -1,12 +1,5 @@
 module.exports = {
   rules: {
-    'import/no-extraneous-dependencies': [
-      'error',
-      {
-        devDependencies: ['**/*.spec.js', '**/*.test.js', '**/tests-*.js', '**/*.spec.ts', '**/*.test.ts', '**/tests-*.ts'],
-        peerDependencies: false,
-      },
-    ],
     'import/prefer-default-export': 'off',
   },
 };


### PR DESCRIPTION
This was a breaking change due to it overriding the existing configuration coming from Airbnb. Rolling this change back.