### PR TITLE
Upgrade to eslint-plugin-unicorn 31.0.0 and remove Node 10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [10, 12, 14]
+        node: [12, 14]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2020 tclindner
+Copyright (c) 2016-2021 tclindner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 
 > ESLint [shareable config](http://eslint.org/docs/developer-guide/shareable-configs.html) for JavaScript projects
 
-
 [![license](https://img.shields.io/github/license/tclindner/eslint-config-tc.svg?maxAge=2592000&style=flat-square)](https://github.com/tclindner/eslint-config-tc/blob/master/LICENSE)
 [![npm](https://img.shields.io/npm/v/eslint-config-tc.svg?maxAge=2592000?style=flat-square)](https://www.npmjs.com/package/eslint-config-tc)
 ![ci](https://github.com/tclindner/eslint-config-tc/workflows/ci/badge.svg?branch=master)
 [![Dependency Status](https://david-dm.org/tclindner/eslint-config-tc.svg?style=flat-square)](https://david-dm.org/tclindner/eslint-config-tc)
 [![devDependency Status](https://david-dm.org/tclindner/eslint-config-tc/dev-status.svg?style=flat-square)](https://david-dm.org/tclindner/eslint-config-tc#info=devDependencies)
-
 
 ## What is eslint-config-tc?
 
@@ -22,7 +20,7 @@ First thing first, let's make sure you have the necessary pre-requisites.
 
 #### Node
 
-* [Node.js](https://nodejs.org/) - v10.0.0+
+* [Node.js](https://nodejs.org/) - v12.0.0+
 * [npm](http://npmjs.com) - v6.0.0+
 
 ### Command
@@ -64,4 +62,4 @@ Please see [CHANGELOG.md](CHANGELOG.md).
 
 ## License
 
-Copyright (c) 2016-2020 Thomas Lindner. Licensed under the MIT license.
+Copyright (c) 2016-2021 Thomas Lindner. Licensed under the MIT license.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tc",
-  "version": "18.1.0",
+  "version": "19.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,9 +14,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.13.11",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.11.tgz",
-      "integrity": "sha512-BwKEkO+2a67DcFeS3RLl0Z3Gs2OvdXewuWjc1Hfokhb5eQWP9YRYH1/+VrVZvql2CfjOiNGqSAFOYt4lsqTHzg==",
+      "version": "7.13.15",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/compat-data/-/compat-data-7.13.15.tgz",
+      "integrity": "sha1-fo7qQtC2T9orN1si0GxgUiLoSPQ=",
       "dev": true
     },
     "@babel/core": {
@@ -61,36 +61,26 @@
       }
     },
     "@babel/eslint-parser": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.13.10.tgz",
-      "integrity": "sha512-/I1HQ3jGPhIpeBFeI3wO9WwWOnBYpuR0pX0KlkdGcRQAVX9prB/FCS2HBpL7BiFbzhny1YCiBH8MTZD2jJa7Hg==",
+      "version": "7.13.14",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/eslint-parser/-/eslint-parser-7.13.14.tgz",
+      "integrity": "sha1-+A/SO92DlTciGRTLXRdyCl6mujo=",
       "dev": true,
       "requires": {
-        "eslint-scope": "5.1.0",
+        "eslint-scope": "^5.1.0",
         "eslint-visitor-keys": "^1.3.0",
         "semver": "^6.3.0"
       },
       "dependencies": {
-        "eslint-scope": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-          "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
         "eslint-visitor-keys": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
           "dev": true
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         }
       }
@@ -107,12 +97,12 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
-      "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
+      "version": "7.13.16",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
+      "integrity": "sha1-bpHczxXj9D5VVt/+MthgEJiHVjw=",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.13.8",
+        "@babel/compat-data": "^7.13.15",
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
         "semver": "^6.3.0"
@@ -120,8 +110,8 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         }
       }
@@ -234,8 +224,8 @@
     },
     "@babel/helper-validator-option": {
       "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-      "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+      "integrity": "sha1-0fvwEuGnm37rv9xtJwuq+NnrmDE=",
       "dev": true
     },
     "@babel/helpers": {
@@ -1463,16 +1453,16 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+      "version": "4.16.5",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/browserslist/-/browserslist-4.16.5.tgz",
+      "integrity": "sha1-lSglRAvKiRPGLQAhM0y+ko7wYq4=",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.649",
+        "caniuse-lite": "^1.0.30001214",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.719",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.70"
+        "node-releases": "^1.1.71"
       }
     },
     "bser": {
@@ -1488,6 +1478,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "3.2.0",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha1-RdXbmefuXmvE82LgCL+RerUEmIc=",
       "dev": true
     },
     "cache-base": {
@@ -1540,9 +1536,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001200",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001200.tgz",
-      "integrity": "sha512-ic/jXfa6tgiPBAISWk16jRI2q8YfjxHnSG7ddSL1ptrIP8Uy11SayFrjXRAk3NumHpDb21fdTkbTxb/hOrFrnQ==",
+      "version": "1.0.30001216",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30001216.tgz",
+      "integrity": "sha1-R0GKCCpPlS0U2JZK5zniXvsgYKk=",
       "dev": true
     },
     "capture-exit": {
@@ -1695,8 +1691,8 @@
     },
     "colorette": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha1-y8x51emcrqLb8Q6zom/Ys+as+pQ=",
       "dev": true
     },
     "combined-stream": {
@@ -2017,9 +2013,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.687",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
-      "integrity": "sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ==",
+      "version": "1.3.721",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/electron-to-chromium/-/electron-to-chromium-1.3.721.tgz",
+      "integrity": "sha1-P2Sg8fWMlHCthETKykWemWeD1dc=",
       "dev": true
     },
     "emittery": {
@@ -2091,8 +2087,8 @@
     },
     "escalade": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
       "dev": true
     },
     "escape-string-regexp": {
@@ -2418,30 +2414,37 @@
       }
     },
     "eslint-plugin-unicorn": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-28.0.2.tgz",
-      "integrity": "sha512-k4AoFP7n8/oq6lBXkdc9Flid6vw2B8j7aXFCxgzJCyKvmaKrCUFb1TFPhG9eSJQFZowqmymMPRtl8oo9NKLUbw==",
+      "version": "31.0.0",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/eslint-plugin-unicorn/-/eslint-plugin-unicorn-31.0.0.tgz",
+      "integrity": "sha1-U+7z9RUt2qUxiI93pCAxPjDZhko=",
       "dev": true,
       "requires": {
-        "ci-info": "^2.0.0",
+        "ci-info": "^3.1.1",
         "clean-regexp": "^1.0.0",
-        "eslint-template-visitor": "^2.2.2",
+        "eslint-template-visitor": "^2.3.2",
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^2.0.0",
         "import-modules": "^2.1.0",
-        "lodash": "^4.17.20",
+        "is-builtin-module": "^3.1.0",
+        "lodash": "^4.17.21",
         "pluralize": "^8.0.0",
         "read-pkg-up": "^7.0.1",
-        "regexp-tree": "^0.1.22",
+        "regexp-tree": "^0.1.23",
         "reserved-words": "^0.1.2",
         "safe-regex": "^2.1.1",
-        "semver": "^7.3.4"
+        "semver": "^7.3.5"
       },
       "dependencies": {
+        "ci-info": {
+          "version": "3.1.1",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/ci-info/-/ci-info-3.1.1.tgz",
+          "integrity": "sha1-mjL87997zbbwp+HA+AmOxXiXuAo=",
+          "dev": true
+        },
         "find-up": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
           "dev": true,
           "requires": {
             "locate-path": "^5.0.0",
@@ -2450,17 +2453,23 @@
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
           "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
           }
         },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
+          "dev": true
+        },
         "p-limit": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -2468,8 +2477,8 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
           "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
@@ -2477,14 +2486,14 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
         "parse-json": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
@@ -2495,14 +2504,14 @@
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
           "dev": true
         },
         "read-pkg": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha1-e/KVQ4yloz5WzTDgU7NO5yUMk8w=",
           "dev": true,
           "requires": {
             "@types/normalize-package-data": "^2.4.0",
@@ -2513,16 +2522,16 @@
           "dependencies": {
             "type-fest": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+              "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha1-jSojcNPfiG61yQraHFv2GIrPg4s=",
               "dev": true
             }
           }
         },
         "read-pkg-up": {
           "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-          "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+          "integrity": "sha1-86YTV1hFlzOuK5VjgFbhhU5+9Qc=",
           "dev": true,
           "requires": {
             "find-up": "^4.1.0",
@@ -2531,9 +2540,9 @@
           }
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -2559,8 +2568,8 @@
     },
     "eslint-template-visitor": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/eslint-template-visitor/-/eslint-template-visitor-2.3.2.tgz",
-      "integrity": "sha512-3ydhqFpuV7x1M9EK52BPNj6V0Kwu0KKkcIAfpUhwHbR8ocRln/oUHgfxQupY8O1h4Qv/POHDumb/BwwNfxbtnA==",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/eslint-template-visitor/-/eslint-template-visitor-2.3.2.tgz",
+      "integrity": "sha1-tS+W/zEedzo0XXkFPMx4J1u8Rj0=",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.16",
@@ -2572,52 +2581,51 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/code-frame/-/code-frame-7.12.13.tgz",
+          "integrity": "sha1-3PyCa+72XnXFDiHTg319lXmN1lg=",
           "dev": true,
           "requires": {
             "@babel/highlight": "^7.12.13"
           }
         },
         "@babel/core": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
-          "integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
+          "version": "7.13.16",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/core/-/core-7.13.16.tgz",
+          "integrity": "sha1-d1arJDlsyWdfHD/NW3n8zhkuqWo=",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
-            "@babel/generator": "^7.13.9",
-            "@babel/helper-compilation-targets": "^7.13.10",
-            "@babel/helper-module-transforms": "^7.13.0",
-            "@babel/helpers": "^7.13.10",
-            "@babel/parser": "^7.13.10",
+            "@babel/generator": "^7.13.16",
+            "@babel/helper-compilation-targets": "^7.13.16",
+            "@babel/helper-module-transforms": "^7.13.14",
+            "@babel/helpers": "^7.13.16",
+            "@babel/parser": "^7.13.16",
             "@babel/template": "^7.12.13",
-            "@babel/traverse": "^7.13.0",
-            "@babel/types": "^7.13.0",
+            "@babel/traverse": "^7.13.15",
+            "@babel/types": "^7.13.16",
             "convert-source-map": "^1.7.0",
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.2",
             "json5": "^2.1.2",
-            "lodash": "^4.17.19",
             "semver": "^6.3.0",
             "source-map": "^0.5.0"
           }
         },
         "@babel/generator": {
-          "version": "7.13.9",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-          "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+          "version": "7.13.16",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/generator/-/generator-7.13.16.tgz",
+          "integrity": "sha1-C+/ChwMaIB2EzfwXO0azIK5HLRQ=",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.13.0",
+            "@babel/types": "^7.13.16",
             "jsesc": "^2.5.1",
             "source-map": "^0.5.0"
           }
         },
         "@babel/helper-function-name": {
           "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-          "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+          "integrity": "sha1-k61lbbPDwiMlWf17LD29y+DrN3o=",
           "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.12.13",
@@ -2627,82 +2635,81 @@
         },
         "@babel/helper-get-function-arity": {
           "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-          "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+          "integrity": "sha1-vGNFHUA6OzCCuX4diz/lvUCR5YM=",
           "dev": true,
           "requires": {
             "@babel/types": "^7.12.13"
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.0.tgz",
-          "integrity": "sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==",
+          "version": "7.13.12",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+          "integrity": "sha1-3+No8m1CagcpnY1lE4IXaCFubXI=",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.13.0"
+            "@babel/types": "^7.13.12"
           }
         },
         "@babel/helper-module-imports": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
-          "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+          "version": "7.13.12",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+          "integrity": "sha1-xqNppvNiHLJdoBQHhoTakZa2GXc=",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.12.13"
+            "@babel/types": "^7.13.12"
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.0.tgz",
-          "integrity": "sha512-Ls8/VBwH577+pw7Ku1QkUWIyRRNHpYlts7+qSqBBFCW3I8QteB9DxfcZ5YJpOwH6Ihe/wn8ch7fMGOP1OhEIvw==",
+          "version": "7.13.14",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+          "integrity": "sha1-5gBlK6SMyxZBd1QTyzLPpOi0le8=",
           "dev": true,
           "requires": {
-            "@babel/helper-module-imports": "^7.12.13",
-            "@babel/helper-replace-supers": "^7.13.0",
-            "@babel/helper-simple-access": "^7.12.13",
+            "@babel/helper-module-imports": "^7.13.12",
+            "@babel/helper-replace-supers": "^7.13.12",
+            "@babel/helper-simple-access": "^7.13.12",
             "@babel/helper-split-export-declaration": "^7.12.13",
             "@babel/helper-validator-identifier": "^7.12.11",
             "@babel/template": "^7.12.13",
-            "@babel/traverse": "^7.13.0",
-            "@babel/types": "^7.13.0",
-            "lodash": "^4.17.19"
+            "@babel/traverse": "^7.13.13",
+            "@babel/types": "^7.13.14"
           }
         },
         "@babel/helper-optimise-call-expression": {
           "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
-          "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+          "integrity": "sha1-XALRcbTIYVsecWP4iMHIHDCiquo=",
           "dev": true,
           "requires": {
             "@babel/types": "^7.12.13"
           }
         },
         "@babel/helper-replace-supers": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.0.tgz",
-          "integrity": "sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==",
+          "version": "7.13.12",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+          "integrity": "sha1-ZEL0wa2RJQJIGlZKc4beDHf/OAQ=",
           "dev": true,
           "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.13.0",
+            "@babel/helper-member-expression-to-functions": "^7.13.12",
             "@babel/helper-optimise-call-expression": "^7.12.13",
             "@babel/traverse": "^7.13.0",
-            "@babel/types": "^7.13.0"
+            "@babel/types": "^7.13.12"
           }
         },
         "@babel/helper-simple-access": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
-          "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
+          "version": "7.13.12",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+          "integrity": "sha1-3WxTivthgZ0gWgEsMXkqOcel6vY=",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.12.13"
+            "@babel/types": "^7.13.12"
           }
         },
         "@babel/helper-split-export-declaration": {
           "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-          "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+          "integrity": "sha1-6UML4AuvPoiw4T5vnU6vITY3KwU=",
           "dev": true,
           "requires": {
             "@babel/types": "^7.12.13"
@@ -2710,25 +2717,25 @@
         },
         "@babel/helper-validator-identifier": {
           "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+          "integrity": "sha1-yaHwIZF9y1zPDU5FPjmQIpgfye0=",
           "dev": true
         },
         "@babel/helpers": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
-          "integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
+          "version": "7.13.17",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/helpers/-/helpers-7.13.17.tgz",
+          "integrity": "sha1-tJfHoA6XGdW2E7iYK9pu0+6UyvY=",
           "dev": true,
           "requires": {
             "@babel/template": "^7.12.13",
-            "@babel/traverse": "^7.13.0",
-            "@babel/types": "^7.13.0"
+            "@babel/traverse": "^7.13.17",
+            "@babel/types": "^7.13.17"
           }
         },
         "@babel/highlight": {
           "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/highlight/-/highlight-7.13.10.tgz",
+          "integrity": "sha1-qLKmYUj1sn1maxXYF3Q0enMdUtE=",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
@@ -2737,15 +2744,15 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.11",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.11.tgz",
-          "integrity": "sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q==",
+          "version": "7.13.16",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/parser/-/parser-7.13.16.tgz",
+          "integrity": "sha1-DxgXmwRI5pObHz9cTDVaOpvN/Tc=",
           "dev": true
         },
         "@babel/template": {
           "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-          "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/template/-/template-7.12.13.tgz",
+          "integrity": "sha1-UwJlvooliduzdSOETFvLVZR/syc=",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
@@ -2754,37 +2761,35 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
-          "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
+          "version": "7.13.17",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/traverse/-/traverse-7.13.17.tgz",
+          "integrity": "sha1-yFQV4MfVCsBT11i67Jiyiy7P7qM=",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
-            "@babel/generator": "^7.13.0",
+            "@babel/generator": "^7.13.16",
             "@babel/helper-function-name": "^7.12.13",
             "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.13.0",
-            "@babel/types": "^7.13.0",
+            "@babel/parser": "^7.13.16",
+            "@babel/types": "^7.13.17",
             "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "globals": "^11.1.0"
           }
         },
         "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+          "version": "7.13.17",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/@babel/types/-/types-7.13.17.tgz",
+          "integrity": "sha1-SAEKEVyfunWItEN91oyUaQErOLQ=",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           }
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -2792,8 +2797,8 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -2803,8 +2808,8 @@
         },
         "color-convert": {
           "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
           "dev": true,
           "requires": {
             "color-name": "1.1.3"
@@ -2812,26 +2817,26 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "globals": {
           "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "json5": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha1-Lf7+cgxrpSXZ69kJlQ8FFTFsiaM=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -2839,14 +2844,14 @@
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -3698,8 +3703,8 @@
     },
     "import-modules": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.1.0.tgz",
-      "integrity": "sha512-8HEWcnkbGpovH9yInoisxaSoIg9Brbul+Ju3Kqe2UsYDUBJD/iQjSgEj0zPcTDPKfPp2fs5xlv1i+JSye/m1/A==",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/import-modules/-/import-modules-2.1.0.tgz",
+      "integrity": "sha1-q+ffKXy2wfGbVyRuuLi9lmS22MI=",
       "dev": true
     },
     "imurmurhash": {
@@ -3773,6 +3778,15 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
+    },
+    "is-builtin-module": {
+      "version": "3.1.0",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
+      "integrity": "sha1-b9skMTscA7dfi5cRwP64wwuQOwA=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^3.0.0"
+      }
     },
     "is-callable": {
       "version": "1.2.2",
@@ -3894,8 +3908,8 @@
     },
     "is-plain-obj": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha1-r28uoUrFpkYYOlu9tbqrvBVq2dc=",
       "dev": true
     },
     "is-plain-object": {
@@ -4849,8 +4863,8 @@
     },
     "lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
@@ -5142,8 +5156,8 @@
     },
     "multimap": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
-      "integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/multimap/-/multimap-1.1.0.tgz",
+      "integrity": "sha1-UmP+vAhaF5HDO1m7OvxqdqKhDKg=",
       "dev": true
     },
     "nanomatch": {
@@ -5206,8 +5220,8 @@
     },
     "node-releases": {
       "version": "1.1.71",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/node-releases/-/node-releases-1.1.71.tgz",
+      "integrity": "sha1-yxM0sXmJaxyJ7P3UtyX7e738fbs=",
       "dev": true
     },
     "normalize-package-data": {
@@ -5578,8 +5592,8 @@
     },
     "pluralize": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha1-Gm+hajjRKhkB4DIPoBcFHFOc47E=",
       "dev": true
     },
     "posix-character-classes": {
@@ -5731,8 +5745,8 @@
     },
     "regexp-tree": {
       "version": "0.1.23",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.23.tgz",
-      "integrity": "sha512-+7HWfb4Bvu8Rs2eQTUIpX9I/PlQkYOuTNbRpKLJlQpSgwSkzFYh+pUj0gtvglnOZLKB6YgnIgRuJ2/IlpL48qw==",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/regexp-tree/-/regexp-tree-0.1.23.tgz",
+      "integrity": "sha1-iozhzF6XGs72IhOn7Nsfbhih8bI=",
       "dev": true
     },
     "regexpp": {
@@ -5941,8 +5955,8 @@
     },
     "safe-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
-      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha1-9xKPANBW4v5cEegaEyTdl0qtztI=",
       "dev": true,
       "requires": {
         "regexp-tree": "~0.1.1"
@@ -7127,8 +7141,8 @@
     },
     "yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "resolved": "https://robustwealth.jfrog.io/robustwealth/api/npm/npm/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
       "dev": true
     },
     "yaml": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5288,9 +5288,9 @@
       }
     },
     "npm-package-json-lint-config-tc": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/npm-package-json-lint-config-tc/-/npm-package-json-lint-config-tc-4.0.0.tgz",
-      "integrity": "sha512-e6CFWeQyM6jw5eqb0Ds/7HFdyrySE7ZDbQ8BXS5zJEmcxg+heiCiX14ZSp3dCwDDXA5ZaMdgukOB5sNVU3k1Qw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/npm-package-json-lint-config-tc/-/npm-package-json-lint-config-tc-4.1.0.tgz",
+      "integrity": "sha512-P33rs7G6tYxKZSRWhPwJ4qBJC3rNyVA5iaAwX62jO5BGBUlrpj71YsC3zjIx/smpFa7aAKvgzWUwSLY9MI2Psw==",
       "dev": true
     },
     "npm-run-path": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tc",
-  "version": "18.1.0",
+  "version": "19.0.0",
   "description": "ESLint shareable config for JavaScript projects",
   "keywords": [
     "eslintconfig",
@@ -40,7 +40,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.3.6",
     "eslint-plugin-prettier": "^3.4.0",
-    "eslint-plugin-unicorn": "^28.0.2",
+    "eslint-plugin-unicorn": "^31.0.0",
     "is-plain-obj": "^3.0.0",
     "jest": "^26.6.3",
     "npm-package-json-lint": "^5.1.0",
@@ -57,7 +57,7 @@
     "eslint-plugin-import": "^2.0.0",
     "eslint-plugin-jest": "^24.0.0",
     "eslint-plugin-prettier": "^3.0.0",
-    "eslint-plugin-unicorn": "^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0",
+    "eslint-plugin-unicorn": ">=25.0.0",
     "prettier": "^2.0.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "prettier": "^2.0.0"
   },
   "engines": {
-    "node": ">=10.0.0",
+    "node": ">=12.0.0",
     "npm": ">=6.0.0"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "is-plain-obj": "^3.0.0",
     "jest": "^26.6.3",
     "npm-package-json-lint": "^5.1.0",
-    "npm-package-json-lint-config-tc": "^4.0.0",
+    "npm-package-json-lint-config-tc": "^4.1.0",
     "prettier": "^2.2.1"
   },
   "dependencies": {

--- a/rules/unicorn.js
+++ b/rules/unicorn.js
@@ -3,5 +3,6 @@ module.exports = {
     'unicorn/no-null': 'off',
     'unicorn/prevent-abbreviations': 'off',
     'unicorn/no-array-for-each': 'off',
+    'unicorn/prefer-module': 'off',
   },
 };


### PR DESCRIPTION
PR to add support up to eslint-plugin-unicorn 31 and disable the rule `unicorn/prefer-module`. 

Draft release notes

### 💥  Breaking Changes
* Upgrade to eslint-plugin-unicorn 31.0.0 (#306)
* Remove support for Node 10 (#306)

### 🧹  Chores
* Bump eslint-plugin-jest from 24.3.1 to 24.3.2 (#293) 
* Bump eslint from 7.22.0 to 7.23.0 (#294)
* Bump y18n from 4.0.0 to 4.0.1 (#295) 
* Bump eslint-plugin-jest from 24.3.2 to 24.3.4 (#296)
* Bump eslint from 7.23.0 to 7.24.0 (#297) 
* Bump eslint-plugin-jest from 24.3.4 to 24.3.5 (#298) 
* Do not run codeql on push (#299)
* Bump eslint-config-prettier from 8.1.0 to 8.2.0 (#300)
* Bump eslint-plugin-prettier from 3.3.1 to 3.4.0 (#301) 
* Bump eslint from 7.24.0 to 7.25.0 (#303) 
* +Bump eslint-config-prettier from 8.2.0 to 8.3.0 (#304) 
* Bump eslint-plugin-jest from 24.3.5 to 24.3.6 (#305) 
