### PR TITLE
Disable unicorn/numeric-separators-style

### DIFF
--- a/rules/unicorn.js
+++ b/rules/unicorn.js
@@ -5,5 +5,6 @@ module.exports = {
     'unicorn/no-array-for-each': 'off',
     'unicorn/prefer-module': 'off',
     'unicorn/prefer-node-protocol': 'off',
+    'unicorn/numeric-separators-style': 'off',
   },
 };


### PR DESCRIPTION
This conflicts with a core eslint rule so disabling it for now. We can consider turning this on with the next major release.